### PR TITLE
upgrade the `pdfbox-version` to the 3.0.5 and fix breaking changes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.dspace.content.Bitstream;
@@ -154,7 +154,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         // same size as the MediaBox if it doesn't exist. Also note that we
         // only need to check the first page, since that's what we use for
         // generating the thumbnail (PDDocument uses a zero-based index).
-        PDPage pdfPage = PDDocument.load(f).getPage(0);
+        PDPage pdfPage = Loader.loadPDF(f).getPage(0);
         PDRectangle pdfPageMediaBox = pdfPage.getMediaBox();
         PDRectangle pdfPageCropBox = pdfPage.getCropBox();
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -11,6 +11,8 @@ import java.awt.image.BufferedImage;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -71,7 +73,7 @@ public class PDFBoxThumbnail extends MediaFilter {
         BufferedImage buf;
 
         // Render the page image.
-        try ( PDDocument doc = PDDocument.load(source); ) {
+        try (PDDocument doc = Loader.loadPDF(new RandomAccessReadBuffer(source)); ) {
             PDFRenderer renderer = new PDFRenderer(doc);
             buf = renderer.renderImage(0);
         } catch (InvalidPasswordException ex) {

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -19,9 +19,9 @@ import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSDocument;
-import org.apache.pdfbox.io.MemoryUsageSetting;
-import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.io.ScratchFile;
 import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -331,18 +331,8 @@ public class PDFPackager
         COSDocument cos = null;
 
         try {
-            ScratchFile scratchFile = null;
-            try {
-                long useRAM = Runtime.getRuntime().freeMemory() * 80 / 100; // use up to 80% of JVM free memory
-                scratchFile = new ScratchFile(
-                    MemoryUsageSetting.setupMixed(useRAM)); // then fallback to temp file (unlimited size)
-            } catch (IOException ioe) {
-                log.warn("Error initializing scratch file: " + ioe.getMessage());
-            }
-
-            PDFParser parser = new PDFParser(new RandomAccessBufferedFileInputStream(metadata), scratchFile);
-            parser.parse();
-            cos = parser.getDocument();
+            PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(metadata));
+            cos = document.getDocument();
 
             // sanity check: PDFBox breaks on encrypted documents, so give up.
             if (cos.getEncryptionDictionary() != null) {

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.dspace.authorize.AuthorizeException;
@@ -264,7 +266,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
 
     private PDDocument loadDocumentFromDB(Context context, Bitstream bitstream) {
         try (var inputStream = bitstreamService.retrieve(context, bitstream)) {
-            return PDDocument.load(inputStream);
+            return Loader.loadPDF(new RandomAccessReadBuffer(inputStream));
         } catch (IOException | SQLException | AuthorizeException e) {
             throw new RuntimeException(e);
         }

--- a/dspace-api/src/main/java/org/dspace/disseminate/PdfGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/PdfGenerator.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -84,7 +85,7 @@ public class PdfGenerator {
     public PDDocument generate(String html) {
         try (var out = new ByteArrayOutputStream()) {
             generate(html, out);
-            return PDDocument.load(out.toByteArray());
+            return Loader.loadPDF(out.toByteArray());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -62,6 +62,8 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -1007,7 +1009,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
              Writer writer = new StringWriter();
-             PDDocument pdfDoc = PDDocument.load(source)) {
+             PDDocument pdfDoc = Loader.loadPDF(new RandomAccessReadBuffer(source))) {
 
             pts.writeText(pdfDoc, writer);
             return writer.toString();
@@ -1016,7 +1018,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
     private int getNumberOfPdfPages(byte[] content) throws IOException {
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
-             PDDocument pdfDoc = PDDocument.load(source)) {
+             PDDocument pdfDoc = Loader.loadPDF(new RandomAccessReadBuffer(source))) {
             return pdfDoc.getNumberOfPages();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.57.v20241219</jetty.version>
         <log4j.version>2.24.3</log4j.version>
-        <pdfbox-version>2.0.33</pdfbox-version>
+        <pdfbox-version>3.0.5</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <!-- SLF4J is not used, but specified for dependency convergence issues between many dependencies -->
         <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
1. Upgrade `pdfbox-version` to the latest version (3.0.5) for safety
2. fix all breaking changes to make sure build success


List of changes in this PR:
* change `PDDocument.load(f)` to `Loader.loadPDF(f)`
* change `PDDocument.load(source);` to `Loader.loadPDF(new RandomAccessReadBuffer(source));`
* change `new PDFParser(new RandomAccessBufferedFileInputStream(metadata), scratchFile)` to `Loader.loadFDF(metadata);`



Finally, we `mvn clean package` and all build failures are fixed.
